### PR TITLE
Python 3.6 has gone final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - 3.3
   - 3.4
   - 3.5
-  - 3.5-dev
+  - 3.6
   - nightly
   - pypy
   - pypy3
@@ -29,4 +29,4 @@ after_success:
 
 notifications:
   email:
-    - ryan.parman@wepay.com
+    - vasusen@wepay.com

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all:
 install-python:
 	versions=""
 
-	for version in "3.6" "3.5.2" "3.4.5" "3.3.6" "2.7.12" "pypy-5.3.1" "pypy3-2.4.0"; do \
+	for version in "3.6.0" "3.5.2" "3.4.5" "3.3.6" "2.7.12" "pypy-5.3.1" "pypy3-2.4.0"; do \
 		pyenv install $$version; \
 		versions="$$version $$versions"; \
 	done;

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all:
 install-python:
 	versions=""
 
-	for version in "3.6.0" "3.5.2" "3.4.5" "3.3.6" "2.7.12" "pypy-5.3.1" "pypy3-2.4.0"; do \
+	for version in "3.6.0" "3.5.2" "3.4.5" "3.3.6" "2.7.13" "pypy-5.3.1" "pypy3-2.4.0"; do \
 		pyenv install $$version; \
 		versions="$$version $$versions"; \
 	done;

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all:
 install-python:
 	versions=""
 
-	for version in "3.6-dev" "3.5.2" "3.4.5" "3.3.6" "2.7.12" "pypy-5.3.1" "pypy3-2.4.0"; do \
+	for version in "3.6" "3.5.2" "3.4.5" "3.3.6" "2.7.12" "pypy-5.3.1" "pypy3-2.4.0"; do \
 		pyenv install $$version; \
 		versions="$$version $$versions"; \
 	done;


### PR DESCRIPTION
* References to the development versions of Python 3.6 have been replaced with _final_ identifiers.
* Changed Travis CI failure contact from `ryan.parman@wepay.com` to `vasusen@wepay.com`.